### PR TITLE
chore: Docker improvements — non-root user, multi-arch CI, bridge networking, container docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -30,6 +31,16 @@ jobs:
       - name: Run tests
         run: CGO_ENABLED=0 go test -p 1 -count=1 ./...
 
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -44,3 +55,6 @@ jobs:
         run: scripts/aur-push.sh
         env:
           AUR_KEY: ${{ secrets.AUR_KEY }}
+
+      - name: Wait for propagation
+        run: sleep 150

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -82,7 +82,7 @@ aurs:
       - "wl-clipboard: for Wayland clipboard sync"
       - "xclip: for X11 clipboard sync"
       - "sshfs: for SFTP mounting support"
-      - "playerctl: for MPRIS media control"
+
       - "ydotool: for Wayland mousepad support"
       - "xdotool: for X11 mousepad support"
       - "wtype: for Wayland keyboard emulation"
@@ -107,6 +107,41 @@ aurs:
       install -Dm644 "./packaging/ufw-kcd" "${pkgdir}/etc/ufw/applications.d/kcd"
 
       install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/kcd-bin/LICENSE"
+
+dockers:
+  - image_templates:
+      - "ghcr.io/bethropolis/kcd:{{.Version}}-amd64"
+      - "ghcr.io/bethropolis/kcd:latest-amd64"
+    use: docker
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+
+  - image_templates:
+      - "ghcr.io/bethropolis/kcd:{{.Version}}-arm64"
+      - "ghcr.io/bethropolis/kcd:latest-arm64"
+    use: docker
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+
+docker_manifests:
+  - name_template: "ghcr.io/bethropolis/kcd:{{.Version}}"
+    image_templates:
+      - "ghcr.io/bethropolis/kcd:{{.Version}}-amd64"
+      - "ghcr.io/bethropolis/kcd:{{.Version}}-arm64"
+  - name_template: "ghcr.io/bethropolis/kcd:latest"
+    image_templates:
+      - "ghcr.io/bethropolis/kcd:latest-amd64"
+      - "ghcr.io/bethropolis/kcd:latest-arm64"
 
 nfpms:
   - id: packages
@@ -215,6 +250,11 @@ release:
     Headless KDE Connect daemon for Linux.
 
     ### Installation
+
+    **Docker:**
+    ```bash
+    docker pull ghcr.io/bethropolis/kcd:latest
+    ```
 
     **Arch Linux:**
     ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,17 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
       -o /out/kcd \
       ./cmd/kcd
 
+# Pre-create empty directories owned by nobody:nogroup (65534:65534)
+# so the runtime container can run unprivileged and still write to them.
+RUN mkdir -p /out/empty && \
+    for d in config state data run/kcd; do \
+        mkdir -p "/out/$d"; \
+    done && \
+    chown -R 65534:65534 /out/config /out/state /out/data /out/run
+
 # Smoke-test: binary must be statically linked
-RUN file /out/kcd | grep -q "statically linked" || \
+RUN apk add --no-cache file && \
+    file /out/kcd | grep -q "statically linked" || \
     (echo "ERROR: binary is not statically linked" && exit 1)
 
 # ─── Runtime ───────────────────────────────────────────────────────────────────
@@ -44,11 +53,21 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 # The binary
 COPY --from=builder /out/kcd /usr/bin/kcd
 
+# Pre-populate volume mount points with directories owned by nobody
+# so the container runs unprivileged without permission errors.
+COPY --from=builder --chown=65534:65534 /out/config /config
+COPY --from=builder --chown=65534:65534 /out/state /state
+COPY --from=builder --chown=65534:65534 /out/data /data
+COPY --from=builder --chown=65534:65534 /out/run /run
+
 # Volume mount points — must be provided at runtime
-# /config  → $XDG_CONFIG_HOME/kcd  (kcd.toml, cert.pem, key.pem)
-# /state   → $XDG_STATE_HOME/kcd   (devices.json — persisted pairs)
-# /data    → download_dir           (received files)
+# /config → $XDG_CONFIG_HOME/kcd  (kcd.toml, cert.pem, key.pem)
+# /state  → $XDG_STATE_HOME/kcd   (devices.json — persisted pairs)
+# /data   → download_dir           (received files)
 VOLUME ["/config", "/state", "/data"]
+
+# Drop privileges — nobody can still bind ports ≥1024 and write to volumes.
+USER 65534:65534
 
 # kcd reads these to find its paths without a real home directory
 ENV XDG_CONFIG_HOME=/config \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kcd — Headless KDE Connect Daemon
+# kcd - Headless KDE Connect Daemon
 
 [![Go Version](https://img.shields.io/badge/Go-1.25%2B-00ADD8?style=for-the-badge&logo=go&logoColor=white)](https://golang.org)
 [![Protocol](https://img.shields.io/badge/KDE%20Connect-v8-4CAF50?style=for-the-badge&logoColor=white)](https://valent.andyholmes.ca/documentation/protocol.html)
@@ -6,7 +6,7 @@
 [![Release](https://img.shields.io/github/v/release/bethropolis/kcd?style=for-the-badge&logo=github&color=181717&logoColor=white)](https://github.com/bethropolis/kcd/releases/latest)
 [![Build](https://img.shields.io/github/actions/workflow/status/bethropolis/kcd/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white&label=build)](https://github.com/bethropolis/kcd/actions/workflows/ci.yml)
 [![GHCR](https://img.shields.io/badge/container-ghcr.io-2496ED?style=for-the-badge&logo=docker&logoColor=white)](https://github.com/bethropolis/kcd/pkgs/container/kcd)
-[![Platforms](https://img.shields.io/badge/Platforms-Linux%20%7C%20macOS-6e40c9?style=for-the-badge&logoColor=white)](https://github.com/bethropolis/kcd)
+[![Platforms](https://img.shields.io/badge/Platform-Linux-6e40c9?style=for-the-badge&logoColor=white)](https://github.com/bethropolis/kcd)
 
 `kcd` is a lightweight, headless implementation of the [KDE Connect protocol v8](https://kdeconnect.kde.org/) written in Go. It lets Linux servers, containers, and minimal desktop environments participate in the KDE Connect ecosystem without a GUI, a full KDE installation, or heavy D-Bus dependencies.
 
@@ -34,7 +34,8 @@
 
 Discovery is dual-mode: **UDP broadcast** (port 1716) and **mDNS/Zeroconf** (`_kdeconnect._udp`), so `kcd` works on both simple home networks and restricted environments (corporate Wi-Fi, Docker, university networks) where broadcast packets are dropped.
 
-> **Broadcast is off by default.** It only runs during `kcd pair` (listen mode) and stops immediately after. The UDP/mDNS **listener** stays always-on, so paired devices reconnect automatically via remembered IPs at 0.0% idle CPU.
+> [!NOTE]
+> Broadcast is off by default. It only runs during `kcd pair` (listen mode) and stops immediately after. The UDP/mDNS **listener** stays always-on, so paired devices reconnect automatically via remembered IPs at 0.0% idle CPU.
 
 ---
 
@@ -57,6 +58,10 @@ Install from the AUR using your preferred helper:
 yay -S kcd-bin
 ```
 
+### Container
+
+Multi-arch images on GHCR: [`docs/CONTAINER.md`](docs/CONTAINER.md)
+
 ### Binary releases
 
 Download the latest pre-built binary from [GitHub Releases](https://github.com/bethropolis/kcd/releases).
@@ -66,7 +71,7 @@ Download the latest pre-built binary from [GitHub Releases](https://github.com/b
 
 ## Firewall
 
-KDE Connect requires three port ranges to be open on the local machine:
+KDE Connect needs three port ranges open:
 
 | Port | Protocol | Direction | Purpose |
 |---|---|---|---|
@@ -74,17 +79,13 @@ KDE Connect requires three port ranges to be open on the local machine:
 | 1716 | TCP | bidirectional | Encrypted control channel |
 | 1739–1764 | TCP | inbound | File transfer side-channels |
 
+> **Installed via .deb, .rpm, or AUR?** The firewall rules are already in place
+> — nothing to do on your end. These steps are only needed for manual installs.
+
 ### UFW (Ubuntu / Debian)
 ```bash
 sudo cp packaging/ufw-kcd /etc/ufw/applications.d/kcd
 sudo ufw allow kcd
-```
-
-Or manually:
-```bash
-sudo ufw allow 1716/udp
-sudo ufw allow 1716/tcp
-sudo ufw allow 1739:1764/tcp
 ```
 
 ### firewalld (Fedora / RHEL)
@@ -94,21 +95,38 @@ sudo firewall-cmd --permanent --add-service=kcd
 sudo firewall-cmd --reload
 ```
 
+### Manual
+```bash
+sudo ufw allow 1716/udp
+sudo ufw allow 1716/tcp
+sudo ufw allow 1739:1764/tcp
+```
+
 ---
 
 ## Quick Start
 
 ### 1. Start the daemon
 
-```bash
-# Run directly in the foreground
-kcd daemon
+If you installed via the script, `.deb`, `.rpm`, or AUR, the systemd user service
+is already set up — enable and start it:
 
-# Or install and enable the systemd user unit
-cp packaging/kcd-user.service ~/.config/systemd/user/kcd.service
-systemctl --user daemon-reload
+```bash
 systemctl --user enable --now kcd
 ```
+
+Check that it's running:
+
+```bash
+systemctl --user status kcd
+```
+
+To run in the foreground instead (for testing):
+
+```bash
+kcd daemon
+```
+
 
 ### 2. Discover your phone
 
@@ -133,10 +151,8 @@ Two ways to pair:
 kcd pair a1b2c3d4_e5f6_7890_abcd_ef1234567890
 ```
 
-Accept on your phone. Watch for confirmation:
-```bash
-kcd watch --events=pair.accepted
-```
+you can accept the pair request on your phone
+
 
 **B. Listen mode — accept any incoming request (headless/server):**
 ```bash
@@ -144,6 +160,7 @@ kcd pair
 ```
 
 Broadcast starts automatically so the phone can find the PC. Accept on the phone, the CLI confirms and exits. Broadcast stops immediately. Press Ctrl+C to cancel.
+
 
 ### 4. Use it
 
@@ -169,12 +186,12 @@ kcd watch
 # Watch device connect/disconnect live
 kcd devices --watch
 
-# SFTP — browse the phone's filesystem
-kcd sftp request <id>    # Request credentials from the phone
-kcd sftp info <id>       # Show cached credentials and storage volumes
-kcd sftp volumes <id>    # List available storage roots (multiPaths)
-kcd sftp mount <id>      # Mount via sshfs and open in file manager
-kcd sftp unmount <id>    # Unmount a previously mounted filesystem
+# List MPRIS players on the phone and control playback
+kcd mpris list
+kcd mpris play
+kcd mpris pause
+kcd mpris next
+kcd mpris previous
 ```
 
 ---
@@ -237,13 +254,7 @@ See [`packaging/kcd.example.toml`](packaging/kcd.example.toml) for the full anno
 
 ### Nautilus / GNOME Files
 
-Right-click any file in Nautilus to send it directly to a paired device:
-
-```bash
-mkdir -p ~/.local/share/nautilus-python/extensions
-cp packaging/nautilus-kcd.py ~/.local/share/nautilus-python/extensions/
-nautilus -q   # Restart Nautilus to load the extension
-```
+Most of the installation methods, add the [kcd nautilus plugin](packaging/nautilus-kcd.py) which allows you to right-click any file in Nautilus to send it directly to a paired device.
 
 ### Waybar (phone battery widget)
 
@@ -257,7 +268,7 @@ Add to `~/.config/waybar/config`:
 }
 ```
 
-A ready-made config snippet and stylesheet are in [`kcd-waybar-integration/`](kcd-waybar-integration/).
+A ready-made config snippet, python script and stylesheet are in [`kcd-waybar-integration/`](kcd-waybar-integration/).
 
 ### Tiling WM shortcuts (Sway / Hyprland)
 
@@ -266,7 +277,12 @@ A ready-made config snippet and stylesheet are in [`kcd-waybar-integration/`](kc
 bindsym Super+c exec kcd clipboard
 
 # Ring the phone
-bindsym Super+Shift+f exec kcd findmyphone $(kcd devices --json | jq -r '.[0].ID')
+bindsym Super+Shift+f exec kcd findmyphone
+
+# Control phone music playback
+bindsym Super+Shift+period exec kcd mpris next
+bindsym Super+Shift+comma exec kcd mpris previous
+bindsym Super+Shift+m exec kcd mpris toggle
 ```
 
 ### Custom event scripts
@@ -347,6 +363,17 @@ kcd connect 192.168.1.100
 
 ---
 
+## Further Reading
+
+| Document | Description |
+|---|---|
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | System architecture, plugin system, event bus, IPC protocol |
+| [`docs/CLI.md`](docs/CLI.md) | Full CLI reference and sub-commands |
+| [`docs/CONTAINER.md`](docs/CONTAINER.md) | Running kcd in Docker / Podman |
+| [`packaging/kcd.example.toml`](packaging/kcd.example.toml) | Annotated configuration reference |
+
+---
+
 ## License
 
-MIT
+[MIT](./LICENSE)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,11 @@
 services:
 
-  # ────────────────────────────────────────────────────────────────────────────
-  # kcd daemon
+  # ════════════════════════════════════════════════════════════════════════════
+  # kcd daemon — host networking (default profile)
   #
-  # IMPORTANT: network_mode: host is required for KDE Connect to work.
-  #   - UDP broadcast (discovery) only reaches devices on the same LAN when
-  #     the container shares the host network stack.
-  #   - mDNS (zeroconf) requires multicast, which is unavailable on bridge nets.
-  #   - Removing host networking will break device discovery entirely.
-  # ────────────────────────────────────────────────────────────────────────────
+  # Required for UDP broadcast and mDNS discovery to reach the LAN.
+  # Ports are irrelevant with host networking — the host firewall applies.
+  # ════════════════════════════════════════════════════════════════════════════
   kcd:
     image: ghcr.io/bethropolis/kcd:latest
     # Uncomment to build locally instead:
@@ -21,41 +18,22 @@ services:
     #     DATE: unknown
     container_name: kcd
 
-    # Required for UDP broadcast and mDNS discovery to reach the LAN.
-    # Ports are irrelevant when using host networking — the host firewall applies.
     network_mode: host
-
     restart: unless-stopped
 
     environment:
-      # Override these to change where kcd stores its files inside the container.
-      # The Dockerfile defaults are shown; you usually don't need to change them.
       XDG_CONFIG_HOME: /config
       XDG_STATE_HOME: /state
       XDG_RUNTIME_DIR: /run
       XDG_CACHE_HOME: /tmp
-
-      # Optional: set log level without editing kcd.toml
       # KCD_LOG_LEVEL: debug
 
     volumes:
-      # Config directory — holds kcd.toml, cert.pem, key.pem.
-      # Create kcd.toml here before first run (copy from packaging/kcd.example.toml).
       - kcd-config:/config
-
-      # State directory — holds devices.json (paired device fingerprints).
-      # Persist this so you don't need to re-pair after container restarts.
       - kcd-state:/state
-
-      # Download directory — received files land here.
-      # Map to a host path so you can access received files outside Docker.
       - ${KCD_DOWNLOAD_DIR:-./downloads}:/data
-
-      # IPC socket — expose outside the container so the host CLI can talk to it.
-      # After: kcd --config /path/to/config devices   (or use the bind below)
       - kcd-run:/run
 
-    # Resource limits — kcd is very lean at idle (0.0% CPU with broadcast off).
     deploy:
       resources:
         limits:
@@ -72,20 +50,60 @@ services:
       start_period: 15s
       retries: 3
 
-  # ────────────────────────────────────────────────────────────────────────────
-  # kcd-cli  (optional helper)
+  # ════════════════════════════════════════════════════════════════════════════
+  # kcd daemon — bridge networking (profile: bridge)
+  #
+  # Use this profile on Docker Swarm, Kubernetes, or when host networking is
+  # unavailable. Note that:
+  #   - UDP broadcast is confined to the bridge network (no LAN discovery).
+  #   - mDNS may also be blocked. Paired devices reconnect via remembered IP.
+  #   - Manually connect to the phone: kcd connect <phone-ip>
+  # ════════════════════════════════════════════════════════════════════════════
+  kcd-bridge:
+    image: ghcr.io/bethropolis/kcd:latest
+    container_name: kcd-bridge
+    profiles:
+      - bridge
+    network_mode: bridge
+    restart: unless-stopped
+
+    ports:
+      - "1716:1716/tcp"
+      - "1716:1716/udp"
+      - "1739-1764:1739-1764/tcp"
+
+    environment:
+      XDG_CONFIG_HOME: /config
+      XDG_STATE_HOME: /state
+      XDG_RUNTIME_DIR: /run
+      XDG_CACHE_HOME: /tmp
+
+    volumes:
+      - kcd-config:/config
+      - kcd-state:/state
+      - ${KCD_DOWNLOAD_DIR:-./downloads}:/data
+      - kcd-run:/run
+
+    healthcheck:
+      test: ["/usr/bin/kcd", "devices"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # kcd-cli  (optional helper, profile: cli)
   #
   # Runs kcd subcommands against the daemon's Unix socket.
   # Usage:
   #   docker compose run --rm kcd-cli devices
   #   docker compose run --rm kcd-cli pair <device-id>
-  #   docker compose run --rm kcd-cli watch
-  # ────────────────────────────────────────────────────────────────────────────
+  # ════════════════════════════════════════════════════════════════════════════
   kcd-cli:
     image: ghcr.io/bethropolis/kcd:latest
     container_name: kcd-cli
     profiles:
-      - cli           # Only started when explicitly requested
+      - cli
     network_mode: host
     volumes:
       - kcd-config:/config
@@ -94,21 +112,18 @@ services:
       XDG_CONFIG_HOME: /config
       XDG_RUNTIME_DIR: /run
     entrypoint: ["/usr/bin/kcd"]
-    # Default: list devices. Override at `docker compose run` time.
     command: ["devices"]
     depends_on:
       kcd:
         condition: service_healthy
 
 volumes:
-  # Named volumes for daemon data — survive container recreation.
   kcd-config:
     driver: local
   kcd-state:
     driver: local
   kcd-run:
     driver: local
-    # tmpfs keeps the Unix socket in memory — cleaner than a bind mount.
     driver_opts:
       type: tmpfs
       device: tmpfs

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -1,0 +1,77 @@
+# Running kcd in a Container
+
+All commands below use `docker` but work identically with `podman` (just
+replace `docker` with `podman`).
+
+Multi-architecture images (linux/amd64, linux/arm64) are published to
+[ghcr.io/bethropolis/kcd](https://github.com/bethropolis/kcd/pkgs/container/kcd).
+
+```bash
+docker pull ghcr.io/bethropolis/kcd:latest
+```
+
+## Quick Start (host networking)
+
+Device discovery (UDP broadcast + mDNS) requires the container to share the host
+network stack:
+
+```bash
+docker run -d \
+  --name kcd \
+  --network host \
+  --restart unless-stopped \
+  -v kcd-config:/config \
+  -v kcd-state:/state \
+  -v ${PWD}/downloads:/data \
+  ghcr.io/bethropolis/kcd:latest
+```
+
+## docker-compose / podman-compose
+
+The [`docker-compose.yml`](../docker-compose.yml) at the project root provides
+two networking profiles (compatible with both `docker compose` and
+`podman-compose`):
+
+| Profile | Command | Use case |
+|---|---|---|
+| `default` | `docker compose up -d` | Host networking — device discovery works |
+| `bridge` | `docker compose --profile bridge up -d` | Swarm / K8s — no LAN broadcast, use `kcd connect <ip>` |
+
+The compose file also includes a `kcd-cli` service (profile: `cli`) for running
+subcommands against the daemon's Unix socket:
+
+```bash
+docker compose run --rm kcd-cli devices
+```
+
+## Volumes
+
+| Path | Contents | Required |
+|---|---|---|
+| `/config` | `kcd.toml`, `cert.pem`, `key.pem` | Yes |
+| `/state` | `devices.json` (persisted pairs) | Yes |
+| `/data` | Received files | Optional |
+| `/run` | IPC Unix socket | Yes (tmpfs recommended) |
+
+The container runs as UID 65534 (nobody). All volume directories are pre-created
+in the image with correct ownership, so bind mounts must grant write access to
+UID 65534.
+
+## Building Locally
+
+```bash
+docker build \
+  --build-arg VERSION=dev \
+  --build-arg COMMIT=$(git rev-parse --short HEAD) \
+  --build-arg DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+  -t kcd:local .
+```
+
+## Notes
+
+- Bridge networking loses UDP broadcast discovery. Paired phones reconnect
+  automatically via remembered IP, or use `kcd connect <phone-ip>`.
+- `notify-send` and other desktop-integration tools are **not** available inside
+  the container (no D-Bus session bus). Plugins that depend on them are no-ops.
+- The healthcheck runs `kcd devices` against the daemon's IPC socket — it only
+  passes once the daemon is fully initialised.


### PR DESCRIPTION
## Changes

**Dockerfile:** Non-root user (UID 65534), pre-created owned directories, static binary smoke test fix (install `file`).

**GoReleaser:** `dockers` + `docker_manifests` for multi-arch (amd64, arm64) image publishing. Removed `playerctl` from AUR optdepends.

**CI:** `packages: write` permission, ghcr.io login, Docker Buildx setup. 150s propagation sleep at end.

**compose:** Split into `default` (host) and `kcd-bridge` (profile: bridge) services.

**Docs:** New `docs/CONTAINER.md` with full setup guide. README improvements — systemd-first startup, cleaner firewall, MPRIS usage, further reading links.